### PR TITLE
Update plugin.js

### DIFF
--- a/Resources/Private/News/Templates/Vue/plugin.js
+++ b/Resources/Private/News/Templates/Vue/plugin.js
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import CeNews_pi1 from "nuxt-typo3-headless-news/Resources/Private/News/Templates/Vue/CeNews_pi1";
+import CeNews_pi1 from "nuxt-typo3-headless-news/Resources/Private/News/Templates/Vue/CeNews_pi1.vue";
 export default () => {
   Vue.component("CeNews_pi1", CeNews_pi1);
 };


### PR DESCRIPTION
- added `.vue` file extension
  - there can be projects, where no file extension will be interpreted
    as `.js` or `.ts`, which results in a path that cannot be found
  - when the path canot be found, a whole app crashs with "module not found"